### PR TITLE
Fixed hasCapacity when rate is 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ Throttle.prototype.set = function(options, value) {
 Throttle.prototype.hasCapacity = function() {
   // make requestTimes `this.rate` long. Oldest request will be 0th index
   if (this._requestTimes.length > this.rate) {
-    this._requestTimes = _.last(this._requestTimes, this.rate);
+    this._requestTimes = _.castArray(_.last(this._requestTimes, this.rate));
   }
   return (
     // not paused


### PR DESCRIPTION
When the second argument of _.last is omitted or set to 1, _.last simply returns the last element, not an array. In hasCapacity, this means _requestTimes is set to a number instead of an array, causing a number of problems.

My fix simply uses the lodash castArray function to ensure that _requestTimes remains an array.

References:
https://lodash.com/docs#last
https://lodash.com/docs#castArray
