### PR TITLE
Pull request to support older environments, browsers, and other module loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,24 @@ A plugin for [superagent](https://github.com/visionmedia/superagent) that
  * Follows [superagent](https://github.com/visionmedia/superagent)
    `.use(throttle.plugin())` architecture
  * Hackable
+ * Should work with Browserify
  * Can use multiple instances
 
 ## Install
 
 ```
+  npm i --save superagent
+  npm i --save inherits
   npm i --save superagent-throttle
 ```
 
 ## Basic Usage
 
-    const request     = require('superagent')
-    const _           = require('underscore')
-    const Throttle    = require('superagent-throttle')
+    var request     = require('superagent')
+    var _           = require('underscore')
+    var Throttle    = require('superagent-throttle')
 
-    let throttle = new Throttle({
+    var throttle = new Throttle({
       active: true,     // set false to pause queue
       rate: 5,          // how many requests can be sent every `ratePer`
       ratePer: 10000,   // number of ms in which `rate` requests may be sent
@@ -38,7 +41,7 @@ A plugin for [superagent](https://github.com/visionmedia/superagent) that
     })
 
     _.each(_.range(1, 15), function(iteration) {
-      let width = 100 + iteration
+      var width = 100 + iteration
       request
       .get('http://placekitten.com/' + width + '/100')
       .use(throttle.plugin())
@@ -56,7 +59,7 @@ do that by passing a uri (not necessarily a valid url) to `throttle.plugin`, for
 those requests you want to serialise, and leave it out for other async requests.
 This can be done on the fly, you don't need to initialise subqueues first.
 
-    let endpoint = 'http://example.com/endpoint'
+    var endpoint = 'http://example.com/endpoint'
     request
     .get(endpoint)
     .set('someData': someData)

--- a/index.js
+++ b/index.js
@@ -1,46 +1,57 @@
-var inherits = require('inherits');
-var EventEmitter = require('events').EventEmitter;
-
-// Throttle inherits from EventEmitter
-inherits(Throttle, EventEmitter);
-
-/**
- * ## default options
- */
-var defaults = {
-  // not sure if `name` is used anymore
-  name: 'default',
-  // start unpaused ?
-  active: true,
-  // requests per `ratePer` ms
-  rate: 40,
-  // ms per `rate` requests
-  ratePer: 40000,
-  // max concurrent requests
-  concurrent: 20
-}
-
-/**
- * ## Throttle
- * The throttle object.
- *
- * @class
- * @param {object} options - key value options
- */
- 
-function Throttle(options) {
-   EventEmitter.call(this);
-   // instance properties
-    this._options({
-      _requestTimes: [0],
-      _current: 0,
-      _buffer: [],
-      _serials: {},
-      _timeout: false
+(function (root, factory) {
+  if(typeof define === "function" && define.amd) {
+    define(["inherits", "events"], function(inherits, events){
+      return (root.Throttle = factory(inherits, events));
     });
-    this._options(defaults);
-    this._options(options);
-};
+  } else if(typeof module === "object" && module.exports) {
+    module.exports = (root.Throttle = factory(require("inherits"), require("events")));
+  } else {
+    root.Throttle = factory(root.inherits, root.events);
+  }
+}(this, function(inherits, events) {
+    
+    var EventEmitter = events.EventEmitter;
+  
+    // Throttle inherits from EventEmitter
+    inherits(Throttle, EventEmitter);
+
+    /**
+     * ## default options
+     */
+    var defaults = {
+      // not sure if `name` is used anymore
+      name: 'default',
+      // start unpaused ?
+      active: true,
+      // requests per `ratePer` ms
+      rate: 40,
+      // ms per `rate` requests
+      ratePer: 40000,
+      // max concurrent requests
+      concurrent: 20
+    }
+
+    /**
+     * ## Throttle
+     * The throttle object.
+     *
+     * @class
+     * @param {object} options - key value options
+     */
+     
+    function Throttle(options) {
+       EventEmitter.call(this);
+       // instance properties
+        this._options({
+          _requestTimes: [0],
+          _current: 0,
+          _buffer: [],
+          _serials: {},
+          _timeout: false
+        });
+        this._options(defaults);
+        this._options(options);
+    };
 
 
   /**
@@ -105,9 +116,16 @@ function Throttle(options) {
     ) {
       return false;
     }
-    var idx = throttle._buffer.findIndex(function(request) {
-      return !request.serial || !throttle._serials[request.serial];
-    });
+    var idx = -1;
+    
+    for (var i = 0; i < throttle._buffer.length; i++) {
+        var r = throttle._buffer[i];
+        if(!r.serial || !throttle._serials[r.serial]) {
+            idx = i;
+            break;
+        }
+    }
+    
     if (idx === -1) {
       throttle._isSerialBound = true;
       return false;
@@ -262,6 +280,7 @@ function Throttle(options) {
     }
     //return _.isObject(serial) ? patch(serial) : patch
   }
-
-
-module.exports = Throttle;
+  
+  return Throttle;
+  
+}));

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
-'use strict'
-//const _             = require('lodash')
-const EventEmitter  = require('events')
+var inherits = require('inherits');
+var EventEmitter = require('events').EventEmitter;
+
+// Throttle inherits from EventEmitter
+inherits(Throttle, EventEmitter);
 
 /**
  * ## default options
  */
-let defaults = {
+var defaults = {
   // not sure if `name` is used anymore
   name: 'default',
   // start unpaused ?
@@ -25,20 +27,21 @@ let defaults = {
  * @class
  * @param {object} options - key value options
  */
-class Throttle extends EventEmitter {
-  constructor(options) {
-    super()
-    // instance properties
+ 
+function Throttle(options) {
+   EventEmitter.call(this);
+   // instance properties
     this._options({
       _requestTimes: [0],
       _current: 0,
       _buffer: [],
       _serials: {},
       _timeout: false
-    })
-    this._options(defaults)
-    this._options(options)
-  }
+    });
+    this._options(defaults);
+    this._options(options);
+};
+
 
   /**
    * ## _options
@@ -48,8 +51,8 @@ class Throttle extends EventEmitter {
    * @param {Object} options - key value object
    * @returns null
    */
-  _options(options) {
-    for (let property in options) {
+  Throttle.prototype._options = function(options) {
+    for (var property in options) {
       if (options.hasOwnProperty(property)) {
         this[property] = options[property]
       }
@@ -71,15 +74,12 @@ class Throttle extends EventEmitter {
    * @param {Mixed} [value] - value for key
    * @returns null
    */
-  options(options, value) {
-    if (
-      (typeof options === 'string') &&
-      (value)
-    ) {
-      options = { options: value }
+  Throttle.prototype.options = function(options, value) {
+    if ((typeof options === 'string') && (value)) {
+      options = { options: value };
     }
-    this._options(options)
-    this.cycle()
+    this._options(options);
+    this.cycle();
   }
 
   /**
@@ -88,11 +88,10 @@ class Throttle extends EventEmitter {
    *
    * @returns {Boolean}
    */
-  next() {
-    let throttle = this
+  Throttle.prototype.next = function() {
+    var throttle = this;
     // make requestTimes `throttle.rate` long. Oldest request will be 0th index
-    throttle._requestTimes =
-      throttle._requestTimes.slice(throttle.rate * -1)
+    throttle._requestTimes = throttle._requestTimes.slice(throttle.rate * -1);
 
     if (
       // paused
@@ -104,17 +103,17 @@ class Throttle extends EventEmitter {
       // something waiting in the throttle
       !(throttle._buffer.length)
     ) {
-      return false
+      return false;
     }
-    let idx = throttle._buffer.findIndex((request) => {
-      return !request.serial || !throttle._serials[request.serial]
-    })
+    var idx = throttle._buffer.findIndex(function(request) {
+      return !request.serial || !throttle._serials[request.serial];
+    });
     if (idx === -1) {
-      throttle._isSerialBound = true
-      return false
+      throttle._isSerialBound = true;
+      return false;
     }
-    throttle.send(throttle._buffer.splice(idx, 1)[0])
-    return true
+    throttle.send(throttle._buffer.splice(idx, 1)[0]);
+    return true;
   }
 
   /**
@@ -135,19 +134,19 @@ class Throttle extends EventEmitter {
    * @param {Request} request superagent request
    * @param {Boolean} state new state for serial
    */
-  serial(request, state) {
-    let serials = this._serials
-    let throttle = this
+  Throttle.prototype.serial = function(request, state) {
+    var serials = this._serials;
+    var throttle = this;
     if (request.serial === false) {
-      return
+      return;
     }
     if (state === undefined) {
-      return serials[request.serial]
+      return serials[request.serial];
     }
     if (state === false) {
-      throttle._isSerialBound = false
+      throttle._isSerialBound = false;
     }
-    serials[request.serial] = state
+    serials[request.serial] = state;
   }
 
   /**
@@ -156,12 +155,12 @@ class Throttle extends EventEmitter {
    *
    * @returns {Boolean}
    */
-  _isRateBound() {
-    let throttle = this
+  Throttle.prototype._isRateBound = function() {
+    var throttle = this;
     return (
       ((Date.now() - throttle._requestTimes[0]) < throttle.ratePer) &&
       (throttle._buffer.length > 0)
-    )
+    );
   }
 
   /**
@@ -175,12 +174,12 @@ class Throttle extends EventEmitter {
    * @param {Request} request the superagent request
    * @returns null
    */
-  cycle(request) {
-    let throttle = this
+  Throttle.prototype.cycle = function(request) {
+    var throttle = this;
     if (request) {
-      throttle._buffer.push(request)
+      throttle._buffer.push(request);
     }
-    clearTimeout(throttle._timeout)
+    clearTimeout(throttle._timeout);
 
     // fire requests
     // throttle.next will return false if there's no capacity or throttle is
@@ -189,15 +188,15 @@ class Throttle extends EventEmitter {
 
     // if bound by rate, set timeout to reassess later.
     if (throttle._isRateBound()) {
-      let timeout
+      var timeout;
       // defined rate
-      timeout = throttle.ratePer
+      timeout = throttle.ratePer;
       // less ms elapsed since oldest request
-      timeout -= (Date.now() - throttle._requestTimes[0])
+      timeout -= (Date.now() - throttle._requestTimes[0]);
       // + 1 ms to ensure you don't fire a request exactly ratePer ms later
       throttle._timeout = setTimeout(function() {
-        throttle.cycle()
-      }, timeout)
+        throttle.cycle();
+      }, timeout);
     }
   }
 
@@ -207,31 +206,31 @@ class Throttle extends EventEmitter {
    * @param {Request} request superagent request
    * @returns null
    */
-  send(request) {
-    let throttle = this
-    throttle.serial(request, true)
+  Throttle.prototype.send = function(request) {
+    var throttle = this;
+    throttle.serial(request, true);
     // attend to the throttle once we get a response
-    request.on('end', () => {
-      throttle._current -= 1
-      this.emit('received', request)
+    request.on('end', function() {
+      throttle._current -= 1;
+      throttle.emit('received', request);
 
       if (
         (!throttle._buffer.length) &&
         (!throttle._current)
       ) {
-        this.emit('drained')
+        throttle.emit('drained');
       }
-      throttle.serial(request, false)
-      throttle.cycle()
+      throttle.serial(request, false);
+      throttle.cycle();
     })
 
 
     // original `request.end` was stored at `request.throttled`
     // original `callback` was stored at `request._callback`
-    request.throttled.apply(request, [ request._callback ])
-    throttle._requestTimes.push(Date.now())
-    throttle._current += 1
-    this.emit('sent', request)
+    request.throttled.apply(request, [ request._callback ]);
+    throttle._requestTimes.push(Date.now());
+    throttle._current += 1;
+    this.emit('sent', request);
   }
 
   /**
@@ -244,26 +243,25 @@ class Throttle extends EventEmitter {
    * @param {string} serial any string is ok, it's just a namespace
    * @returns null
    */
-  plugin(serial) {
-    let throttle = this
-    //let patch = function(request) {
-    return (request) => {
-      request.throttle = throttle
-      request.serial = serial || false
+  Throttle.prototype.plugin = function(serial) {
+    var throttle = this;
+    //var patch = function(request) {
+    return function(request) {
+      request.throttle = throttle;
+      request.serial = serial || false;
       // replace request.end
-      request.throttled = request.end
+      request.throttled = request.end;
       request.end = function(callback) {
         // store callback as superagent does
-        request._callback = callback
+        request._callback = callback;
         // place this request in the queue
-        request.throttle.cycle(request)
-        return request
+        request.throttle.cycle(request);
+        return request;
       }
-      return request
+      return request;
     }
     //return _.isObject(serial) ? patch(serial) : patch
   }
-}
 
 
-module.exports = Throttle
+module.exports = Throttle;


### PR DESCRIPTION
I removed the ES6 specific features so the code will work on older JS environments such as Node 0.12.2 or older browsers. It can also be loaded by RequireJS and it should work with browserify although I haven't actually testing with browserify yet. The goal was to make superagent-throttle work in the same environments that superagent works in.
