### PR TITLE
(#10) Throw error when no error event handlers attached

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -215,7 +215,7 @@ class Throttle extends EventEmitter {
     // declare callback within this enclosure, for access to throttle & request
     function cleanup (err, response) {
       throttle._current -= 1
-      if (err) {
+      if (err && EventEmitter.listenerCount(throttle, 'error')) {
         throttle.emit('error', response)
       }
       throttle.emit('received', request)

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,12 @@ nock('http://stub')
 .socketDelay(2000)
 .times(1000)
 .reply(200, '<html></html>')
+
+nock('http://stub')
+.get('/error')
+.times(1000)
+.reply(400)
+
 nock.disableNetConnect()
 
 /**
@@ -260,5 +266,16 @@ describe('throttle', function () {
     let instance = request.get('stub/time')
     let returned = instance.use(throttle.plugin())
     assert(instance === returned, 'instance not returned')
+  })
+
+  it('should not throw error when error listeners are attached', done => {
+    const throttle = new Throttle()
+      .on('error', () => null)
+    const instance = request.get('stub/error')
+      .use(throttle.plugin())
+
+    assert.doesNotThrow(() =>
+      instance.end(() => done())
+    )
   })
 })


### PR DESCRIPTION
So I determined that I was simply missing an 'error' listener being wired up. Needing that isn't really highlighted in docs for superagent, nor should it be I think - one would think that event producers would silently hum along if there are no recipients at any given time...

That said, I spent a lot of time digging in the wrong direction - when no corresponding handler is present, Node's EventEmitter appears to throw its own error that hides the underlying error. 

This change throws the error when no listeners are present, giving the underlying issue versus the cryptic one from Node.

I was only able to add a test for the positive test when a listener does exist. I tried numerous methods of catching the async methods error, but it just isn't possible.

Feel free to throw away if you disagree.